### PR TITLE
Update ember-cli-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-preprocess-registry": "^3.0.0",
-    "ember-cli-sass": "6.0.0",
+    "ember-cli-sass": "^6.0.0",
     "ember-getowner-polyfill": "^1.0.1",
     "object-assign": "^4.0.1",
     "rsvp": "^3.2.0"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-preprocess-registry": "^3.0.0",
-    "ember-cli-sass": "^5.3.1",
+    "ember-cli-sass": "6.0.0",
     "ember-getowner-polyfill": "^1.0.1",
     "object-assign": "^4.0.1",
     "rsvp": "^3.2.0"


### PR DESCRIPTION
Having flexi with ember-cli-sass 5.x and using 6.x in my apps and addons was causing things to break. I propose we update to 6.0.0, and release it as part of the major breaking update we will have when we split everything out.