### PR TITLE
fix(css) revert PR 99; go back to max-width

### DIFF
--- a/addon/styles/grid/_mixins.scss
+++ b/addon/styles/grid/_mixins.scss
@@ -4,7 +4,7 @@
   padding-right: pixel($gutter-padding / 2);
   padding-left:  pixel($gutter-padding / 2);
   @include flex(1 0 percentage($size / $columns));
-  width: percentage($size / $columns);
+  max-width: percentage($size / $columns);
 }
 
 
@@ -88,6 +88,10 @@
       }
 
       // offsets
+      // NOTE: Offsets result in unexpected child widths in Chrome versions
+      // earlier than v56 and all current Safari versions (as of 2017-01-04).
+      // It is currently recommended that you use a <box> sized to the offset
+      // you need.
       @for $i from 0 through ($columns - 1) {
         @if $breakpoint-counter != 1 or $i != 0 { // Avoid emitting useless .col-xs-offset-0
           .#{$col-prefix}offset-#{$bp-prefix}-#{$i} {


### PR DESCRIPTION
Changing columns to use `width` instead of `max-width` breaks wrapped flex children. Better to live with a [hopefully seldomly used] wonky offset attribute than broken wrapping.

In better news, the max-width fix will be in Chrome v56 https://bugs.chromium.org/p/chromium/issues/detail?id=675333 which is released to stable around end of January.