### PR TITLE
Update to use Babel 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "chalk": "^1.1.3",
-    "ember-cli-babel": "^5.1.7",
+    "ember-cli-babel": "^6.0.0-beta.7",
     "semver": "^5.3.0"
   },
   "devDependencies": {
@@ -43,7 +43,7 @@
     "ember-cli-eslint": "^3.0.0",
     "ember-cli-github-pages": "0.0.8",
     "ember-cli-htmlbars": "^1.1.1",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.6",
+    "ember-cli-htmlbars-inline-precompile": "^0.4.0-beta.2",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^3.1.0",
     "ember-cli-sass": "6.1.2",


### PR DESCRIPTION
See http://emberjs.com/blog/2017/03/19/ember-2-12-released.html#toc_babel-6 for details.

Seemed good to update before releasing 2.0.0 final, and may get more testers and whatnot...